### PR TITLE
Decrement DIV_LOCH_SX when tuning vco

### DIFF
--- a/src/LMS7002M_sxx.c
+++ b/src/LMS7002M_sxx.c
@@ -56,10 +56,9 @@ int LMS7002M_sxx_calc_tune_state(
     s->good = false;
 
     //calculation loop to find dividers that are possible
-    while (true)
+    for (s->DIV_LOCH_SX = 6; s->DIV_LOCH_SX >= 0; --(s->DIV_LOCH_SX))
     {
         //try the next divider power
-        s->DIV_LOCH_SX++;
         divRatio_LOCH = 1 << s->DIV_LOCH_SX;
         s->fdiv = divRatio_LOCH*2;
 
@@ -69,8 +68,8 @@ int LMS7002M_sxx_calc_tune_state(
 
         //check dividers and vco in range...
         if (s->fdiv > 128) return -1;
-        if (s->Ndiv < 4) continue;
-        if (s->Ndiv > 512) return -1;
+        if (s->Ndiv < 4) return -1;
+        if (s->Ndiv > 512) continue;
 
         //check vco boundaries
         if (s->fvco < VCO_LO) continue;


### PR DESCRIPTION
When there is overlap in frequencies between dividers, decrementing
selects the higher of the two. This matches the approach used in
LimeSuite, found in `LMS7002M::SetFrequencySX`

We were having issues where tuning of RX would fail at divisions of 
3800Mhz (1900, 950, etc)

The following chart shows the minimum and maximum fvco range for each divider

fdiv | min | max
-- | -- | --
2 | 1900 | 3857
4 | 950 | 1928.5
8 | 475 | 964.25
16 | 237.5 | 482.125
32 | 118.75 | 241.0625
64 | 59.375 | 120.53125
128 | 29.6875 | 60.265625

during the overlaps, such as 1900-1928.5,  selecting the lower divisor would cause the `VCO_CMPLO_SXR` register to register as `1`, indicating a voltage lower than 180mV and the tuning would fail.  This failure would not occur on all chips, but it would occur on most. 


